### PR TITLE
Ensure that evaluation description is never null

### DIFF
--- a/supabase/migrations/20230317182255_add_default_evaluation_description.sql
+++ b/supabase/migrations/20230317182255_add_default_evaluation_description.sql
@@ -1,0 +1,3 @@
+update evaluation set description = '' where description is null;
+alter table evaluation alter column description set default '';
+alter table evaluation alter column set not null;


### PR DESCRIPTION
This was the easiest way to fix errors caused by operating on null when a string is expected.