### PR TITLE
Fix upsertvote by adding composite primary key

### DIFF
--- a/supabase/migrations/20230317182256_add_pkey_to_votes_table.sql
+++ b/supabase/migrations/20230317182256_add_pkey_to_votes_table.sql
@@ -1,0 +1,1 @@
+alter table votes add constraint votes_pkey primary key (evaluator_id, submission_id);


### PR DESCRIPTION
Broken since migration. Failed to copy composite primary key to the new table, which broke the upsert.